### PR TITLE
support custom accept header

### DIFF
--- a/lib/json_hyperschema/client_builder.ex
+++ b/lib/json_hyperschema/client_builder.ex
@@ -74,9 +74,13 @@ defmodule JSONHyperschema.ClientBuilder do
           env()[:headers] || []
         end
 
+        def accept do
+          env()[:accept] || "application/json"
+        end
+
         def headers do
           h = [
-            "Accept": "application/json",
+            "Accept": accept(),
             "Content-Type": "application/json",
           ] ++ env_headers()
         end


### PR DESCRIPTION
This was needed to get `ex_heroku_client` to work again, as it now requires an accept header of `"application/vnd.heroku+json; version=3"`.